### PR TITLE
Resolved issue around inability to evaluate and overflow in sigmoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Google, Inc, August 2017. Profit of $19.37.
 
 To train the model, download a training and test csv files from [Yahoo! Finance](https://ca.finance.yahoo.com/quote/%5EGSPC/history?p=%5EGSPC) into `data/`
 ```
-mkdir model
+mkdir models
 python train ^GSPC 10 1000
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Then when training finishes (minimum 200 episodes for results):
 python evaluate.py ^GSPC_2011 model_ep1000
 ```
 
+## Some changes I had to modify from original
+- Had to modify sigmoid slightly to prevent overflow occuring in Math.exp
+- Added a boolean for first iteration which forces a buy so there is something in agent.inventory  (May look into finding the best statistical time to buy in a future imp based on the current price of entry...for now this has gotten things working when evaluating)
+
 ## References
 
 [Deep Q-Learning with Keras and Gym](https://keon.io/deep-q-learning/) - Q-learning overview and Agent skeleton code

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -21,6 +21,7 @@ class Agent:
 		self.epsilon = 1.0
 		self.epsilon_min = 0.01
 		self.epsilon_decay = 0.995
+		self.first = True
 
 		self.model = load_model("models/" + model_name) if is_eval else self._model()
 
@@ -35,16 +36,21 @@ class Agent:
 		return model
 
 	def act(self, state):
-		if not self.is_eval and np.random.rand() <= self.epsilon:
+		rand_val = np.random.rand()
+		if not self.is_eval and rand_val <= self.epsilon:
 			return random.randrange(self.action_size)
 
+		if(self.first):
+			self.first = False
+			return 1
 		options = self.model.predict(state)
+		#print("Using prediction")
 		return np.argmax(options[0])
 
 	def expReplay(self, batch_size):
 		mini_batch = []
 		l = len(self.memory)
-		for i in xrange(l - batch_size + 1, l):
+		for i in range(l - batch_size + 1, l):
 			mini_batch.append(self.memory[i])
 
 		for state, action, reward, next_state, done in mini_batch:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -21,7 +21,7 @@ class Agent:
 		self.epsilon = 1.0
 		self.epsilon_min = 0.01
 		self.epsilon_decay = 0.995
-		self.first = True
+		self.firstIter = True
 
 		self.model = load_model("models/" + model_name) if is_eval else self._model()
 
@@ -40,7 +40,7 @@ class Agent:
 		if not self.is_eval and rand_val <= self.epsilon:
 			return random.randrange(self.action_size)
 
-		if(self.first):
+		if(self.firstIter):
 			self.first = False
 			return 1
 		options = self.model.predict(state)

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -41,7 +41,7 @@ class Agent:
 			return random.randrange(self.action_size)
 
 		if(self.firstIter):
-			self.first = False
+			self.firstIter = False
 			return 1
 		options = self.model.predict(state)
 		#print("Using prediction")

--- a/evaluate.py
+++ b/evaluate.py
@@ -5,45 +5,50 @@ from agent.agent import Agent
 from functions import *
 import sys
 
-if len(sys.argv) != 3:
-	print "Usage: python evaluate.py [stock] [model]"
+try:
+	if len(sys.argv) != 3:
+		print ("Usage: python evaluate.py [stock] [model]")
+		exit()
+
+	stock_name, model_name = sys.argv[1], sys.argv[2]
+	model = load_model("models/" + model_name)
+	window_size = model.layers[0].input.shape.as_list()[1]
+
+	agent = Agent(window_size, True, model_name)
+	data = getStockDataVec(stock_name)
+	l = len(data) - 1
+	batch_size = 32
+
+	state = getState(data, 0, window_size + 1)
+	total_profit = 0
+	agent.inventory = []
+
+	for t in range(l):
+		action = agent.act(state)
+
+		# sit
+		next_state = getState(data, t + 1, window_size + 1)
+		reward = 0
+
+		if action == 1: # buy
+			agent.inventory.append(data[t])
+			print ("Buy: " + formatPrice(data[t]))
+
+		elif action == 2 and len(agent.inventory) > 0: # sell
+			bought_price = agent.inventory.pop(0)
+			reward = max(data[t] - bought_price, 0)
+			total_profit += data[t] - bought_price
+			print ("Sell: " + formatPrice(data[t]) + " | Profit: " + formatPrice(data[t] - bought_price))
+
+		done = True if t == l - 1 else False
+		agent.memory.append((state, action, reward, next_state, done))
+		state = next_state
+
+		if done:
+			print ("--------------------------------")
+			print (stock_name + " Total Profit: " + formatPrice(total_profit))
+			print ("--------------------------------")
+		
+
+finally:
 	exit()
-
-stock_name, model_name = sys.argv[1], sys.argv[2]
-model = load_model("models/" + model_name)
-window_size = model.layers[0].input.shape.as_list()[1]
-
-agent = Agent(window_size, True, model_name)
-data = getStockDataVec(stock_name)
-l = len(data) - 1
-batch_size = 32
-
-state = getState(data, 0, window_size + 1)
-total_profit = 0
-agent.inventory = []
-
-for t in xrange(l):
-	action = agent.act(state)
-
-	# sit
-	next_state = getState(data, t + 1, window_size + 1)
-	reward = 0
-
-	if action == 1: # buy
-		agent.inventory.append(data[t])
-		print "Buy: " + formatPrice(data[t])
-
-	elif action == 2 and len(agent.inventory) > 0: # sell
-		bought_price = agent.inventory.pop(0)
-		reward = max(data[t] - bought_price, 0)
-		total_profit += data[t] - bought_price
-		print "Sell: " + formatPrice(data[t]) + " | Profit: " + formatPrice(data[t] - bought_price)
-
-	done = True if t == l - 1 else False
-	agent.memory.append((state, action, reward, next_state, done))
-	state = next_state
-
-	if done:
-		print "--------------------------------"
-		print stock_name + " Total Profit: " + formatPrice(total_profit)
-		print "--------------------------------"

--- a/evaluate.py
+++ b/evaluate.py
@@ -49,6 +49,8 @@ try:
 			print (stock_name + " Total Profit: " + formatPrice(total_profit))
 			print ("--------------------------------")
 		
+		if len(agent.memory) > batch_size:
+				agent.expReplay(batch_size) 
 
 finally:
 	exit()

--- a/functions.py
+++ b/functions.py
@@ -17,14 +17,24 @@ def getStockDataVec(key):
 
 # returns the sigmoid
 def sigmoid(x):
-	return 1 / (1 + math.exp(-x))
+	try:
+		if x < 0:
+			return 1 - 1 / (1 + math.exp(x))
+		return 1 / (1 + math.exp(-x))
+	except OverflowError as err:
+		print("Overflow err: {0} - Val of x: {1}".format(err, x))
+	except ZeroDivisionError:
+		print("division by zero!")
+	except Exception as err:
+		print("Error in sigmoid: " + err)
+	
 
 # returns an an n-day state representation ending at time t
 def getState(data, t, n):
 	d = t - n + 1
 	block = data[d:t + 1] if d >= 0 else -d * [data[0]] + data[0:t + 1] # pad with t0
 	res = []
-	for i in xrange(n - 1):
+	for i in range(n - 1):
 		res.append(sigmoid(block[i + 1] - block[i]))
 
 	return np.array([res])

--- a/train.py
+++ b/train.py
@@ -2,52 +2,55 @@ from agent.agent import Agent
 from functions import *
 import sys
 
-if len(sys.argv) != 4:
-	print "Usage: python train.py [stock] [window] [episodes]"
+try:
+	if len(sys.argv) != 4:
+		print ("Usage: python train.py [stock] [window] [episodes]")
+		exit()
+
+	stock_name, window_size, episode_count = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+
+	agent = Agent(window_size)
+	data = getStockDataVec(stock_name)
+	l = len(data) - 1
+	batch_size = 32
+
+	for e in range(episode_count + 1):
+		print ("Episode " + str(e) + "/" + str(episode_count))
+		state = getState(data, 0, window_size + 1)
+
+		total_profit = 0
+		agent.inventory = []
+
+		for t in range(l):
+			action = agent.act(state)
+
+			# sit
+			next_state = getState(data, t + 1, window_size + 1)
+			reward = 0
+
+			if action == 1: # buy
+				agent.inventory.append(data[t])
+				print ("Buy: " + formatPrice(data[t]))
+
+			elif action == 2 and len(agent.inventory) > 0: # sell
+				bought_price = agent.inventory.pop(0)
+				reward = max(data[t] - bought_price, 0)
+				total_profit += data[t] - bought_price
+				print ("Sell: " + formatPrice(data[t]) + " | Profit: " + formatPrice(data[t] - bought_price))
+
+			done = True if t == l - 1 else False
+			agent.memory.append((state, action, reward, next_state, done))
+			state = next_state
+
+			if done:
+				print ("--------------------------------")
+				print ("Total Profit: " + formatPrice(total_profit))
+				print ("--------------------------------")
+
+			if len(agent.memory) > batch_size:
+				agent.expReplay(batch_size)
+
+		if e % 10 == 0:
+			agent.model.save("models/model_ep" + str(e))
+finally:
 	exit()
-
-stock_name, window_size, episode_count = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-
-agent = Agent(window_size)
-data = getStockDataVec(stock_name)
-l = len(data) - 1
-batch_size = 32
-
-for e in xrange(episode_count + 1):
-	print "Episode " + str(e) + "/" + str(episode_count)
-	state = getState(data, 0, window_size + 1)
-
-	total_profit = 0
-	agent.inventory = []
-
-	for t in xrange(l):
-		action = agent.act(state)
-
-		# sit
-		next_state = getState(data, t + 1, window_size + 1)
-		reward = 0
-
-		if action == 1: # buy
-			agent.inventory.append(data[t])
-			print "Buy: " + formatPrice(data[t])
-
-		elif action == 2 and len(agent.inventory) > 0: # sell
-			bought_price = agent.inventory.pop(0)
-			reward = max(data[t] - bought_price, 0)
-			total_profit += data[t] - bought_price
-			print "Sell: " + formatPrice(data[t]) + " | Profit: " + formatPrice(data[t] - bought_price)
-
-		done = True if t == l - 1 else False
-		agent.memory.append((state, action, reward, next_state, done))
-		state = next_state
-
-		if done:
-			print "--------------------------------"
-			print "Total Profit: " + formatPrice(total_profit)
-			print "--------------------------------"
-
-		if len(agent.memory) > batch_size:
-			agent.expReplay(batch_size)
-
-	if e % 10 == 0:
-		agent.model.save("models/model_ep" + str(e))


### PR DESCRIPTION
Was always getting a profit of 0 when evaluating model. This was primarily due to a "Buy" never occurring and therefore agent.inventory was always empty. So I set it so the first iteration a buy will occur and then the model will pick up from there. I'm thinking that in a future adjustment to this, we can infer the best time to buy in to the model based on the sliding window, or perhaps another means. For now, this at least allows for the evaluation to occur on other datasets.

Sigmoid was also overflowing when gamma (x) was higher than what math.exp could handle which on my system was around 700. The implementation used was one with which I found on SO.